### PR TITLE
Faster run times for multiple VG's

### DIFF
--- a/lib/lvm/volume_groups.rb
+++ b/lib/lvm/volume_groups.rb
@@ -23,15 +23,25 @@ module LVM
     def each 
       vgs = @vgs.list
       
+      lvs = Array.new
+      @lvs.each do |lv|
+        lvs << lv
+      end
+      
+      pvs = Array.new
+      @pvs.each do |pv|
+        pvs << pv
+      end
+      
       vgs.each do |vg|
         vg.logical_volumes ||= []
-        @lvs.each do |lv|
+        lvs.each do |lv|
           if lv.vg_uuid == vg.uuid
             vg.logical_volumes << lv
           end
         end
         vg.physical_volumes ||= []
-        @pvs.each do |pv|
+        pvs.each do |pv|
           if pv.vg_uuid == vg.uuid
             vg.physical_volumes << pv
           end


### PR DESCRIPTION
When a node has many VG/LVs this gem calls pvs/lvs many many times which can lead to degraded performance. For example it took ~40s on my example node to call `lvm.volume_groups['vg00']` before this patch. now the call takes ~5s. This substantially reduced execution time of our chef-client runs when using the opscode LVM cookbook. additional testing 

https://gist.github.cerner.com/KM022926/a8f280c47a6ff4c46def
