### PR TITLE
Update physical_volumes.rb

### DIFF
--- a/lib/lvm/physical_volumes.rb
+++ b/lib/lvm/physical_volumes.rb
@@ -26,9 +26,9 @@ module LVM
         yield pv
       end
     end
-  end
 
-  def list
-    self.each { }
+    def list
+      self.each { }
+    end
   end
 end


### PR DESCRIPTION
This gem breaks when calling physical_volumes list method which is causing the community lvm cookbook to break.
